### PR TITLE
Adding Docker support to Chesshub

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,6 @@
 {
     "chesshub": {
-        "db": "mongodb://localhost/test"
+        "db": "mongodb://localhost/test",
 	"es":{
 		 "host": "localhost",
 		 "port": "9200"

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,9 @@
 {
     "chesshub": {
         "db": "mongodb://localhost/test"
+	"es":{
+		 "host": "localhost",
+		 "port": "9200"
+    }
     }
 }

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,37 @@
+# Requirements
+- [Docker](https://docs.docker.com/installation/).
+- [docker-compose](https://docs.docker.com/compose/install/).
+
+# Run Docker images
+The compose file consists of 3 containers:
+- MongoDB Container.
+- Elasticsearch Container.
+- Chesshub Container.
+
+```
+$ git clone https://github.com/benas/gamehub.io.git
+$ cd gamhub.io/docker
+$ sudo docker-compose up
+```
+
+# Edit Services Addresses
+
+By default The Chesshub Docker image will try to connect to Mongodb at Host (mongo) and port (27017) and to Elasticsearch at host (elasticsearch) and port (9200), to change that edit the following file:
+
+### docker/chesshub/config/default.json:
+```
+{
+    "chesshub": {
+        "db": "mongodb://mongo/test",
+	"es":{
+		 "host": "elasticsearch",
+		 "port": "9200"
+    }
+}
+}
+```
+# Volumes and data persistence 
+
+By default the compose file is configured to map volumes of both MongoDB, and Elasticsearch to /data/db and /usr/share/elasticsearch/data respictively.
+
+To change this behavior you can edit the compose file to mount the volumes to other place.

--- a/docker/chesshub/Dockerfile
+++ b/docker/chesshub/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:0.10
+MAINTAINER Hussein Galal
+
+ENV GITHUB_REPO=https://github.com/galal-hussein/gamehub.io.git
+
+RUN mkdir -p /var/www/app
+WORKDIR /var/www/app
+
+RUN apt-get update \
+&& apt-get install git \
+&& git clone $GITHUB_REPO . \
+&& npm install 
+
+ADD ./config/default.json config/default.json
+ADD ./initData.js initData.js
+
+EXPOSE 3000
+
+CMD node initData.js; node .

--- a/docker/chesshub/Dockerfile
+++ b/docker/chesshub/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.10
+FROM node:0.10.40
 MAINTAINER Hussein Galal
 
 ENV GITHUB_REPO=https://github.com/galal-hussein/gamehub.io.git
@@ -12,7 +12,7 @@ RUN apt-get update \
 && npm install 
 
 ADD ./config/default.json config/default.json
-ADD ./initData.js initData.js
+#ADD ./initData.js initData.js
 
 EXPOSE 3000
 

--- a/docker/chesshub/config/default.json
+++ b/docker/chesshub/config/default.json
@@ -1,0 +1,9 @@
+{
+    "chesshub": {
+        "db": "mongodb://mongo/test",
+	"es":{
+		 "host": "elasticsearch",
+		 "port": "9200"
+    }
+}
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,25 @@
+mongo:
+  image: mongo:2.2.7
+  ports:
+    - 127.0.0.1:27017:27017
+  volumes:
+    - /data/db:/data/db
+  restart: always
+
+elasticsearch:
+  image: elasticsearch:1.4
+  ports:
+    - 127.0.0.1:9200:9200
+    - 127.0.0.1:9300:9300
+  volumes:
+    - /usr/share/elasticsearch/data:/usr/share/elasticsearch/data
+  restart: always
+
+chesshub:
+  build: ./chesshub
+  ports:
+    - 3000:3000
+  links:
+    - elasticsearch:elasticsearch
+    - mongo:mongo
+  restart: always

--- a/initData.js
+++ b/initData.js
@@ -1,6 +1,8 @@
 var fs = require('fs');
 var mongoose = require('mongoose');
-mongoose.connect('mongodb://localhost/test');
+var config = require('config');
+mongoose.connect(config.get('chesshub.db'));
+//mongoose.connect('mongodb://localhost/test');
 
 fs.readdirSync(__dirname + '/models').forEach(function (file) {
     if (~file.indexOf('.js')) require(__dirname + '/models/' + file);
@@ -57,7 +59,7 @@ User.findOne({email: 'foo@bar.org'} ,function (err, user) {
 /* Init elastic search server */
 
 var elasticsearch = require('elasticsearch');
-var client = new elasticsearch.Client(); // default to localhost:9200
+var client = new elasticsearch.Client({host: "'"+config.get('chesshub.es.host')+":"+config.get('chesshub.es.port')+"'"});
 
 client.ping({
     requestTimeout: 1000

--- a/initData.js
+++ b/initData.js
@@ -59,10 +59,13 @@ User.findOne({email: 'foo@bar.org'} ,function (err, user) {
 /* Init elastic search server */
 
 var elasticsearch = require('elasticsearch');
-var client = new elasticsearch.Client({host: "'"+config.get('chesshub.es.host')+":"+config.get('chesshub.es.port')+"'"});
-
+var connectionString = "http://"+config.get('chesshub.es.host')+":"+config.get('chesshub.es.port');
+var client = new elasticsearch.Client({
+host: connectionString,
+log: 'trace'
+});
 client.ping({
-    requestTimeout: 1000
+    requestTimeout: 5000
 }, function (error) {
     if (error) {
         console.error('elasticsearch is down!');


### PR DESCRIPTION
Basically, docker directory contains docker-compose file to run elasticsearch, mongo, and to build a chesshub Docker image.

A few changes has been made to the initData.js to allow to use configuration to fetch the addresses of mongo and elasticsearch.